### PR TITLE
Add CLI entry points to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,10 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6'
+    python_requires='>=3.6',
+    entry_points={
+        "console_scripts": [
+            "bibtidy = bibtidy:main"
+        ]
+    }
 )


### PR DESCRIPTION
This just sets the [`entry_points`](https://setuptools.pypa.io/en/latest/userguide/entry_point.html) in `setup.py` so that a `bibtidy` script is created when using `pip install`. On a related note, I would suggest a recommendation of [pipx](https://pypa.github.io/pipx/) in the README. Then you can just do `pipx install git+https://github.com/bajinsheng/bibtidy@main` and a `bibtidy` script will be added to your `PATH` in an isolated virtualenv.